### PR TITLE
Use port.device in case port.name is empty

### DIFF
--- a/dji.py
+++ b/dji.py
@@ -38,7 +38,11 @@ com_port_found = False
 
 for port in serial.tools.list_ports.comports(True):
     if port.description.find('DJI USB VCOM For Protocol') == 0:
-        serial_port = serial.Serial(port=port.name, baudrate=baud_rate)
+        port_name = port.name
+        # Fallback for Windows 11: port name is empty, have to parse it:
+        if port_name == None:
+            port_name = port.device
+        serial_port = serial.Serial(port=port_name, baudrate=baud_rate)
         # set color to green
         print('\u001b[32;1m')
         print(port.description, 'found and opened for communication')


### PR DESCRIPTION
On Windows 11 I got this error:

```
❯ python3 dji.py

DJI USB VCOM For Protocol (COM4) found and opened for communication
Your DJI RC-N1 controller runs in Xbox mode now
Happy flying :-)

Use the following key mapping:
  Left Stick: Pitch and Roll
  Right Stick: Yaw and Throttle
  Camera Control Dial all the way to the right: B button
  Camera Control Dial all the way to the left: A button

sorry, no other buttons are supported yet :-(

Press Ctrl+C to stop (or close terminal window)

Could not read/write: Port must be configured before it can be used.
```

`Port must be configured before it can be used.` suggests the `port` variable in the `serial` constructor is incorrect or empty, so I added a fallback that uses `port.device`. Now it works correctly.